### PR TITLE
Replace function pointers with closures to reduce noise.

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -172,7 +172,7 @@ fn node_space<T: Write + 'static, R: Rng + 'static>() -> Box<dyn Fn(&mut Context
             repeat(ws(), 1, ctx.conf.extra_space_max),
         ])(ctx);
 
-        ctx.write_debug("</NODE-CHILDREN>");
+        ctx.write_debug("</NODE-SPACE>");
 
         result
     })


### PR DESCRIPTION
Previously all calls to the `write_literal()` function, as well as many others, had to be inside a lambda, generating a great deal of noise. This moves from function pointers to using the `Fn` trait, which allows them to be closures and reduces noise in the meat of the various generator functions. In addition, this required spreading `'static` lifetimes for the writer and RNG on the context, but no real harm as they should last the lifetime of the program anyway.

